### PR TITLE
Removed unneeded items from options page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![Build Status](https://travis-ci.org/waltzio/waltz.png)](https://travis-ci.org/waltzio/waltz)
+
 # Waltz
 An open source password manager designed to work with Clef
+
+## Contributing Site Configs
+
+To add new sites to Waltz, please add a file to the site_configs directory.  Name the file with the domain of the site you are trying to add, and use the format from the other site configs in that directory.  An official format will be published in this README in the future.
 

--- a/js/options.js
+++ b/js/options.js
@@ -12,12 +12,15 @@
 			for(domain in sites) {
 				var site = sites[domain];
 
-				var html = "<li data-username='"+site.username+"' data-password='"+site.password+"' data-domain='"+domain+"'>"
-						   +"	<h3>"+domain+"</h3>"
-						   +"	<button class='decrypt styled'>Decrypt</button>"
-						   +"	</li>"
+				if(domain != "options" && domain != "waltz_logins"){ //Options and Waltz_logins don't have username/password pairs
 
-				$(".sites-list").find("ul").append(html);
+					var html = "<li data-username='"+site.username+"' data-password='"+site.password+"' data-domain='"+domain+"'>"
+							   +"	<h3>"+domain+"</h3>"
+							   +"	<button class='decrypt styled'>Decrypt</button>"
+							   +"	</li>"
+
+					$(".sites-list").find("ul").append(html);
+				}
 			}
 
 			$(".sites-list").find(".decrypt").click(function() {


### PR DESCRIPTION
"options" and "waltz_logins" kept showing up on the options page when they shouldn't be
