### PR TITLE
Check for logged in state being dynamically loaded

### DIFF
--- a/js/background/delegate.js
+++ b/js/background/delegate.js
@@ -116,10 +116,6 @@ Delegate.prototype.acknowledgeLogin = function(request) {
     this.transitioningToLoggedIn = false;
 }
 
-Delegate.prototype.checkTransition = function(request, cb) {
-    cb(this.transitioningToLoggedIn);
-}
-
 Delegate.prototype.login = function(domain) {
 	if (!this.loggedIn) {
 		this.loggedIn = true;
@@ -319,8 +315,8 @@ Delegate.prototype.initialize = function(data, callback) {
 						domain: site,
 						config: this.siteConfigs[site]
 					},
-					cyHost: this.options.cy_url
-
+					cyHost: this.options.cy_url,
+                    inTransition: this.transitioningToLoggedIn
 				};
 				callback(options);
 				return;

--- a/js/client/waltz.js
+++ b/js/client/waltz.js
@@ -8,7 +8,25 @@
 		if ($(opts.site.config.login.check).length != 0) {
             chrome.runtime.sendMessage({ method: "acknowledgeLogin" });
             return;
-        };
+        } else {
+        	var checks = 0;
+        	var loginCheckInterval = setInterval(function() {
+        		if(checks > 20) {
+        			clearInterval(loginCheckInterval);
+        			return;
+        		}
+
+        		if($(opts.site.config.login.check).length != 0) {
+        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
+        			clearInterval(loginCheckInterval);
+
+        			$(".waltz-dismiss").click();
+        			$("#waltz-credential-overlay").click();
+        		}
+
+        		checks++;
+        	}, 500);
+        }
 
 		var _this = this;
 

--- a/js/client/waltz.js
+++ b/js/client/waltz.js
@@ -3,68 +3,109 @@
 	var Waltz = this.Waltz = function(opts) {
         // If there are no opts, Waltz is not supported on this site
 		if (!opts) return;
-        // If the 'check' selector exists, then we're logged in, 
-        // so don't show Waltz
-		if ($(opts.site.config.login.check).length != 0) {
+
+		this.options = opts;
+		var _this = this,
+			page = this.checkPage();
+        
+		if (page == "logged_in") {
+			// If the 'check' selector exists, then we're logged in, 
+        	// so don't show Waltz
             chrome.runtime.sendMessage({ method: "acknowledgeLogin" });
             return;
         } else {
-        	var checks = 0;
-        	var loginCheckInterval = setInterval(function() {
-        		if(checks > 20) {
-        			clearInterval(loginCheckInterval);
-        			return;
-        		}
+        	// the 'check' selector doesn't exit yet, but it may exist in the 
+        	// near future. 
+        	var checks = 0,
+        		MAX_CHECKS = 20,
+        		CHECK_INTERVAL = 300,
+        		loginCheckInterval;
 
-        		if($(opts.site.config.login.check).length != 0) {
-        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
-        			clearInterval(loginCheckInterval);
+        	if (!this.options.inTransition) {
+        		// If we're not inTransition, let's assume that we need to log
+        		// in. So, kickOff then check to see if we need to hide.
+        		kickOff();
+        		loginCheckInterval = setInterval(function() {
+        			if (checks > MAX_CHECKS) {
+	        			clearInterval(loginCheckInterval);
+	        			return;
+	        		}
 
-        			$(".waltz-dismiss").click();
-        			$("#waltz-credential-overlay").click();
-        		}
+	        		page = _this.checkPage();
+	        		if (page === "logged_in") {
+        				$(".waltz-dismiss").click();
+	        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
+	        			clearInterval(loginCheckInterval);
+	        			return;
+	        		} else if (page == "login") {
+	        			clearInterval(loginCheckInterval);
+	        		} else {
+	        			checks++;
+	        		}
 
-        		checks++;
-        	}, 500);
+        		}, CHECK_INTERVAL);
+
+        	} else {
+	        	// if we are inTransition, let's keep on looking for a login 
+	        	// field. We can do this because the bad password page will
+	        	// almost certainly contain the field to put in a new password.
+	        	// ya feel me?
+	        	if (page === "login") {
+	        		kickOff();
+	        	} else {
+	        		loginCheckInterval = setInterval(function() {
+	        			if (checks > MAX_CHECKS) {
+	        				clearInterval(loginCheckInterval);
+	        				return;
+	        			}
+
+	        			page = _this.checkPage();
+	        			if (page === "logged_in") {
+		        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
+		        			clearInterval(loginCheckInterval);
+		        			return;
+	        			} else if (page === "login") {
+	        				kickOff();
+	        				clearInterval(loginCheckInterval);
+	        				return;
+	        			} else {
+	        				checks++;
+	        			}
+	        		}, CHECK_INTERVAL);
+	        	}
+        	}
         }
 
-		var _this = this;
+        function kickOff() {
+        	_this.loginCredentials = false;
 
-		this.options = opts;
+			chrome.runtime.sendMessage({
+				method: "getCredentials",
+				domain: _this.options.site.domain
 
-		this.loginCredentials = false;
-
-		chrome.runtime.sendMessage({
-			method: "getCredentials",
-			domain: this.options.site.domain
-
-		}, function(creds) {
-			if(creds.error) {
-				if(creds.error === "authentication") {
-					console.log("auth error");
+			}, function(creds) {
+				if(creds.error) {
+					if(creds.error === "authentication") {
+						console.log("auth error");
+					} else {
+						console.log(creds.error, creds.status);
+					}
 				} else {
-					console.log(creds.error, creds.status);
-				}
-			} else {
-				_this.loginCredentials = creds.creds	
-				_this.drawClefWidget();		
+					_this.loginCredentials = creds.creds	
+					_this.drawClefWidget();		
 
-                console.log("Loaded credentials");
-                chrome.runtime.sendMessage({
-                    method: "checkTransition"
-                }, function(inTransition) {
-                    if (inTransition) {
+                    if (_this.options.inTransition) {
                         _this.checkAuthentication(function() {
                             var errorMessage = "Invalid username and password. Please try entering your credentials again.";
                             _this.requestCredentials(errorMessage); 
                         });
                     }
                     chrome.runtime.sendMessage({ method: "acknowledgeLogin" });
-                });
-			}
-		});
+				}
 
-		window.addEventListener('message', this.closeIFrame.bind(this));
+				window.addEventListener('message', _this.closeIFrame.bind(_this));
+			});
+        }
 	}
 
 	Waltz.prototype.storeLogin = function(username, password) {
@@ -222,19 +263,28 @@
 		}
 
 		if (siteConfig.login.other) {
+			var appendInputs = function(data) {
+				var $data = $(data),
+					inputs = $data.find('input');
 
-			chrome.runtime.sendMessage({
-				method: "proxyRequest",
-				url: siteConfig.login.other.url
-			}, function(data) {
-				var $data = $(data);
+				inputs = inputs.filter(function(input) { 
+					return $(this).attr('name') != siteConfig.login.passwordField &&
+						$(this).attr('name') != siteConfig.login.usernameField;
+				});
 
-				for (var i = 0; i < siteConfig.login.other.fields.length; i++) {
-					form.append($data.find('input[name="' + siteConfig.login.other.fields[i] + '"]').clone())
-				}
+				form.append(inputs);
 				
 				submitForm();
-			});
+			}
+
+			if (window.location.href.match(siteConfig.login.other.url)) {
+				appendInputs(document);
+			} else {
+				chrome.runtime.sendMessage({
+					method: "proxyRequest",
+					url: siteConfig.login.other.url
+				}, appendInputs);
+			}
 		} else {
 			submitForm();
 		}
@@ -368,7 +418,6 @@
 
 		$(document).ready(this.loadIFrame.bind(this));
 
-
 		$(clefCircle).click(function() {
 			$(this).addClass("waltz-loading");
 
@@ -403,9 +452,24 @@
 			});
 		});
 
+		$(clefCircle).on('destroyed', function() {
+			console.log('removed!!!');
+		})
 
 		$("body").append(clefCircle);
 
+	}
+
+	Waltz.prototype.checkPage = function() {
+		if ($(this.options.site.config.login.check).length != 0) {
+			return "logged_in";
+		}
+
+		if ($("input[name='" + this.options.site.config.login.passwordField + "']").length > 0) {
+			return "login";
+		}
+
+		return "unknown";
 	}
 
 	chrome.runtime.sendMessage({

--- a/site_configs/crashlytics.json
+++ b/site_configs/crashlytics.json
@@ -1,0 +1,18 @@
+{
+    "*://*.crashlytics.com/*": {
+        "logout": {
+            "cookies": ["auth_token"]
+        },
+        "login": {
+            "url": "https://twitter.com/sessions",
+            "method": "POST",
+            "usernameField": "session[username_or_email]",
+            "passwordField": "session[password]",
+            "other": {
+                "url": "https://twitter.com/login",
+                "fields": ["authenticity_token"]
+            },
+            "check": "button:contains('Sign out')"
+        }
+    }
+}

--- a/site_configs/localhost.json
+++ b/site_configs/localhost.json
@@ -1,0 +1,14 @@
+{
+    "http://localhost/*": {
+        "logout": {
+            "cookies": ["PHPSESSID"]
+        },
+        "login": {
+            "url": "http://localhost/loginTest.php",
+            "method": "POST",
+            "usernameField": "username",
+            "passwordField": "password",
+            "check": "#logged_in"
+        }
+    }
+}

--- a/site_configs/pivotaltracker.json
+++ b/site_configs/pivotaltracker.json
@@ -8,7 +8,7 @@
             "method": "POST",
             "usernameField": "credentials[username]",
             "passwordField": "credentials[password]",
-            "check": "a#signout"
+            "check": "li.person_name"
         }
     }
 }


### PR DESCRIPTION
Some sites will add in the HTML that we are checking against via javascript.  Waltz should recheck to see if we're logged in for some period.  If we are, dismiss the waltz widget.

An unfortunate side-effect of this is that if you're logged in and the check doesn't immediately pass, we drop down the incorrect credentials window.  If Waltz notices the login later I've set it to automatically dismiss the form, but it still feels pretty awful.  @jessepollak @landakram thoughts?
