### PR TITLE
Namespaces logging in variable and starts redirect work

### DIFF
--- a/js/background/delegate.js
+++ b/js/background/delegate.js
@@ -6,10 +6,10 @@
  *
 ********************/
 
-Delegate.prototype.DEBUG = false;
+Delegate.prototype.DEBUG = true;
 
 Delegate.prototype.options = {};
-
+Delegate.prototype.currentLogins = {};
 
 Delegate.prototype.options.configURL = "https://raw.github.com/waltzio/waltz/master/deploy/site_configs.json";
 Delegate.prototype.options.backupConfigURL = chrome.extension.getURL("build/site_configs.json");
@@ -111,9 +111,6 @@ Delegate.prototype.router = function(request, sender, sendResponse) {
 		case "checkAuthentication":
 			return this.checkAuthentication(sendResponse);
 			break;
-		case "login":
-			return this.login(request.domain);
-			break;
 		case "getHost":
 			return sendResponse(this.options.cy_url);
 			break;
@@ -130,17 +127,17 @@ Delegate.prototype.router = function(request, sender, sendResponse) {
 }
 
 Delegate.prototype.acknowledgeLogin = function(request) {
-    this.transitioningToLoggedIn = false;
+    this.currentLogins[request.domain] = false;
 }
 
-Delegate.prototype.login = function(domain) {
+Delegate.prototype.login = function(request) {
 	if (!this.loggedIn) {
 		this.loggedIn = true;
 		this.pubnubSubscribe();
 	}
 
-    this.transitioningToLoggedIn = true;
-	storage.addLogin(domain);
+    this.currentLogins[request.domain] = request.location;
+	storage.addLogin(request.domain);
 }
 
 Delegate.prototype.updateSiteConfigs = function(data) {
@@ -335,7 +332,7 @@ Delegate.prototype.initialize = function(data, callback) {
 						config: this.siteConfigs[site]
 					},
 					cyHost: this.options.cy_url,
-                    inTransition: this.transitioningToLoggedIn
+                    currentLogin: this.currentLogins[site]
 				};
 				callback(options);
 				return;

--- a/js/client/waltz.js
+++ b/js/client/waltz.js
@@ -11,7 +11,7 @@
 		if (page == "logged_in") {
 			// If the 'check' selector exists, then we're logged in, 
         	// so don't show Waltz
-            chrome.runtime.sendMessage({ method: "acknowledgeLogin" });
+    		this.acknowledgeLogin();
             return;
         } else {
         	// the 'check' selector doesn't exit yet, but it may exist in the 
@@ -21,7 +21,7 @@
         		CHECK_INTERVAL = 300,
         		loginCheckInterval;
 
-        	if (!this.options.inTransition) {
+        	if (!this.options.currentLogin) {
         		// If we're not inTransition, let's assume that we need to log
         		// in. So, kickOff then check to see if we need to hide.
         		kickOff();
@@ -34,7 +34,7 @@
 	        		page = _this.checkPage();
 	        		if (page === "logged_in") {
         				$(".waltz-dismiss").click();
-	        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
+			        	this.acknowledgeLogin();
 	        			clearInterval(loginCheckInterval);
 	        			return;
 	        		} else if (page == "login") {
@@ -61,7 +61,7 @@
 
 	        			page = _this.checkPage();
 	        			if (page === "logged_in") {
-		        			chrome.runtime.sendMessage({method: "acknowledgeLogin"});
+				        	this.acknowledgeLogin();
 		        			clearInterval(loginCheckInterval);
 		        			return;
 	        			} else if (page === "login") {
@@ -94,7 +94,7 @@
 					_this.loginCredentials = creds.creds	
 					_this.drawClefWidget();		
 
-                    if (_this.options.inTransition) {
+                    if (_this.options.currentLogin) {
                         _this.checkAuthentication(function() {
                             var errorMessage = "Invalid username and password.";
                             _this.requestCredentials(errorMessage); 
@@ -114,6 +114,13 @@
 			username: username,
 			password: password
 		});
+	}
+
+	Waltz.prototype.acknowledgeLogin = function() {
+		if (this.options.currentLogin) {
+        	chrome.runtime.sendMessage({ method: "acknowledgeLogin", domain: this.options.site.domain });
+			window.location = this.options.currentLogin;
+		}
 	}
 
 	Waltz.prototype.decryptCredentials = function(cb) {
@@ -291,7 +298,8 @@
 		function submitForm() {
 			chrome.runtime.sendMessage({
 	            method: "login",
-	            domain: _this.options.site.domain
+	            domain: _this.options.site.domain,
+	            location: window.location.href
 	        }, function() {});
 
 


### PR DESCRIPTION
This PR does two things:
1. It namespaces the "transitioning" flag to each domain. This solves the bug where you log in on one site and then jump quickly to another and, because the transitioning flag is set, it prompts you to reenter your credentials. With this transitioning flag namespaced, you have to be on the same domain to get that dropdown.
2. It starts the redirect after login. At the moment, we do this on the _client side_, so the page loads and then it redirects. This is because that's easier and it allows us to check whether the user successfully logged in before redirecting them.

PROBLEMS:
1. 2-factor authentication throws a real stick in this thing. It prompts the 're-enter your credentials' modal because after logging in, the user doesn't appear logged in (they aren't).
