### PR TITLE
Stores original URL and redirects after a successful login

### DIFF
--- a/js/background/delegate.js
+++ b/js/background/delegate.js
@@ -66,12 +66,20 @@ function Delegate(options) {
                 var redirectUrl = new URL(_this.currentLogins[domain]);
                 var shouldRedirect = 
                     // If the next URL is the login URL, there's probably an error
-                    (domainUrl.hostname !== loginUrl.hostname || 
-                     domainUrl.pathname !== loginUrl.pathname) &&
+                    ((domainUrl.hostname !== loginUrl.hostname || 
+                      domainUrl.pathname !== loginUrl.pathname)) &&
                     // If the redirect URL is the login URL, let the 
                     // site handle directing the user to the right place
-                    (redirectUrl.hostname !== loginUrl.hostname || 
-                     redirectUrl.pathname !== loginUrl.pathname);
+                    ((redirectUrl.hostname !== loginUrl.hostname || 
+                      redirectUrl.pathname !== loginUrl.pathname));
+                if (siteConfig.login.twoFactor) {
+                    $.map(siteConfig.login.twoFactor, function(twoFactor) {
+                        var twoFactorUrl = new URL(twoFactor.url); 
+                        shouldRedirect &= 
+                            (domainUrl.hostname !== twoFactorUrl.hostname || 
+                             domainUrl.pathname !== twoFactorUrl.pathname);
+                    });
+                }
 
                 redirectUrl = redirectUrl.toString();
                 if (shouldRedirect) {

--- a/js/client/waltz.js
+++ b/js/client/waltz.js
@@ -8,14 +8,15 @@
 		var _this = this,
 			page = this.checkPage();
         
+        // First, we need to figure out if the Waltz icon should be displayed.
 		if (page == "logged_in") {
 			// If the 'check' selector exists, then we're logged in, 
         	// so don't show Waltz
     		this.acknowledgeLogin();
             return;
         } else {
-        	// the 'check' selector doesn't exit yet, but it may exist in the 
-        	// near future. 
+        	// the 'check' selector doesn't exist yet, but it may be loaded 
+            // dynamically by the page.
         	var checks = 0,
         		MAX_CHECKS = 20,
         		CHECK_INTERVAL = 300,

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,8 @@
     "cookies",
     "tabs",
     "notifications",
-    "contextMenus"
+    "contextMenus",
+    "webRequest"
   ],
   "icons": {
     "16": "/img/waltz-16.png",

--- a/site_configs/facebook.json
+++ b/site_configs/facebook.json
@@ -10,7 +10,13 @@
             "method": "POST",
             "usernameField": "email",
             "passwordField": "pass",
-            "check": "input[type='submit'][value='Log Out']"
+            "check": "input[type='submit'][value='Log Out']",
+            "twoFactor": [
+                {
+                    "url": "https://www.facebook.com/checkpoint/",
+                    "check": "input[name]='approvals_code'"
+                }     
+            ]
         }
     }
 }

--- a/site_configs/github.json
+++ b/site_configs/github.json
@@ -14,7 +14,13 @@
                 "url": "https://github.com/login",
                 "fields": ["authenticity_token"]
             },
-            "check": "a#logout"
+            "check": "a#logout",
+            "twoFactor": [
+                {
+                    "url": "https://github.com/session",
+                    "check": "input[name='otp']"
+                }
+            ]
         }
     }
 }

--- a/site_configs/google.json
+++ b/site_configs/google.json
@@ -15,7 +15,13 @@
                 "url": "https://accounts.google.com/ServiceLoginAuth",
                 "fields": ["GALX"]
             },
-            "check": "a#gb_71"
+            "check": "a#gb_71",
+            "twoFactor": [
+                {
+                    "url": "https://accounts.google.com/SecondFactor",
+                    "check": "form[action='SecondFactor']"
+                }
+            ]
         }
     },
     "*://*.youtube.com/*": {
@@ -34,7 +40,13 @@
                 "url": "https://accounts.google.com/ServiceLoginAuth",
                 "fields": ["GALX"]
             },
-            "check": "div#yt-masthead-user"
+            "check": "div#yt-masthead-user",
+            "twoFactor": [
+                {
+                    "url": "https://accounts.google.com/SecondFactor",
+                    "check": "form[action='SecondFactor']"
+                }
+            ]
         }
     }
 }

--- a/site_configs/itunes_connect.json
+++ b/site_configs/itunes_connect.json
@@ -1,0 +1,23 @@
+{
+    "*://itunesconnect.apple.com/*": {
+        "logout": {
+            "cookies": ["user"]
+        },
+        "login": {
+            "url": "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/wo/14.1.9.3.13.2.1.1.3.1.1",
+            "method": "POST",
+            "usernameField": "theAccountName",
+            "passwordField": "theAccountPW",
+            "other": {
+                "url": "https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa",
+                "fields": ["theAuxValue", "1.Continue.x", "1.Continue.y"],
+                "dynamic": {
+                    "1.Continue.x": 67,
+                    "1.Continue.y": 26
+                }     
+            },
+            "check": "a:contains('Sign Out')"
+        }
+    }
+}
+

--- a/site_configs/twitter.json
+++ b/site_configs/twitter.json
@@ -14,7 +14,17 @@
                 "url": "https://twitter.com/login",
                 "fields": ["authenticity_token"]
             },
-            "check": "button:contains('Sign out')"
+            "check": "button:contains('Sign out')",
+            "twoFactor": [
+                {
+                    "url": "https://twitter.com/account/login_verification/push",
+                    "check": "div.login-verification-push"
+                },
+                { 
+                    "url": "https://twitter.com/account/login_verification/sms",
+                    "check": "input[name]='token'"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
This PR will redirect you back to the original page you were viewing before you hit the Waltz button. 

The redirect will not happen in certain cases:
1.  The URL the browser would have navigated to is the login URL. If this is the case, there was most likely an error with the login request (of course, this is a rough heuristic that may not always be true). 
2.  The original URL is the login URL. If this is the case, it's likely that the site will already redirect the user to where they need to be (perhaps using referer or something), so we let the site handle that instead.
3. The URL the browser would have navigated to is a known two-factor URL. This prevents you from missing the two-factor prompt, but still redirects you to the original page afterward.
