### PR TITLE
WordPress.com English

### DIFF
--- a/site_configs/wordpress-en.json
+++ b/site_configs/wordpress-en.json
@@ -1,0 +1,23 @@
+{
+    "*://*.wordpress.com/*": {
+        "name": "WordPress (EN)",
+        "logout": {
+            "cookies": ["wordpress_logged_in"]
+        },
+        "login": {
+			"urls": ["https://en.wordpress.com/wp-login.php","https://wordpress.com/wp-login.php"],
+            "formURL": "https://en.wordpress.com/wp-login.php",
+            "method": "POST",
+            "usernameField": "log",
+            "passwordField": "pwd",
+            "hasHiddenInputs": true,
+            "check": "#wp-admin-bar-logout",
+            "twoFactor": [
+                { 
+                    "url": "https://en.wordpress.com/wp-login.php",
+                    "check": "input[name='twostep-authcode']"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Add WP.com English

Tested and works everywhere on English WP universe save one subdomain:
en.forums. This page appears to load the admin bar via a JS. Since my
“check” element comes from the admin bar, I think there is a sequencing
issue (is it looking for my check element before that element is
loaded?) that causes the Waltz button to appear despite being logged in.
