### PR TITLE
Ignore two sites

### DIFF
--- a/site_configs/dedeo-schola.json
+++ b/site_configs/dedeo-schola.json
@@ -11,6 +11,7 @@
             "usernameField": "username",
             "passwordField": "password",
             "check": "a:contains('Log out')"   
-        }
+        },
+        "ignore": true
     }
 }

--- a/site_configs/runningwarehouse-talk.json
+++ b/site_configs/runningwarehouse-talk.json
@@ -11,6 +11,7 @@
             "usernameField": "vb_login_username",
             "passwordField": "vb_login_password",
             "check": "a:contains('Log Out')"
-        }
+        },
+        "ignore": true
     }
 }


### PR DESCRIPTION
Ignores schola.dedeo.org (the blow to my vanity notwithstanding :-) and Running Warehouse Forum (it is sufficient to list the main site).

Also renames config file for schola.dedeo in an attempt to standardize config file naming pattern: mainsite + hyphen + subsite.
