### PR TITLE
Clean up multiple listings on sites list

### DIFF
--- a/site_configs/amazon.json
+++ b/site_configs/amazon.json
@@ -26,7 +26,8 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }, "*://*.amazon.de/*": {
         "name": "Amazon (DE)",
         "logout": {
@@ -40,7 +41,8 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }, "*://*.amazon.fr/*": {
         "name": "Amazon (FR)",
         "logout": {
@@ -54,7 +56,8 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }, "*://*.amazon.es/*": {
         "name": "Amazon (FR)",
         "logout": {
@@ -68,7 +71,8 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }, "*://*.amazon.it/*": {
         "name": "Amazon (IT)",
         "logout": {
@@ -82,7 +86,8 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }, "*://*.amazon.cn/*": {
         "name": "Amazon (CN)",
         "logout": {
@@ -96,6 +101,7 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "a#nav-item-signout, a:contains('Sign Out'), script:contains('Sign Out')"
-        }
+        },
+        "ignore": true
     }
 }

--- a/site_configs/twitter.json
+++ b/site_configs/twitter.json
@@ -42,6 +42,7 @@
             "passwordField": "password",
             "hasHiddenInputs": true,
             "check": "button:contains('Sign out'), a#sign_out_link"
-        }
+        },
+        "ignore": true
     }
 }


### PR DESCRIPTION
Fixes: https://www.dropbox.com/s/s8hclcrxrqccn72/Screenshot%202014-02-18%2009.59.19.jpg
- I think displaying only .com is the way to go until we figure out a better way to handle all the aspects of the internationalization process
- For the same reason it might make sense to go ahead and merge https://github.com/waltzio/waltz/pull/242, which only displays .com

Also fixes: https://www.dropbox.com/s/amduktzy8ok6pno/Screenshot%202014-02-18%2010.00.13.jpg
