### PR TITLE
Fix how we handle acknowledging logins

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
     "scripts": [
       "static/js/vendor/lodash.min.js",
       "static/js/vendor/jquery.min.js",
+      "static/js/vendor/debug.js",
       "static/js/vendor/pubnub.js",
       "static/js/shared/utils.js",
       "static/js/vendor/raven.min.js",
@@ -34,6 +35,7 @@
     "js": [
       "static/js/vendor/lodash.min.js",
       "static/js/vendor/jquery.min.js",
+      "static/js/vendor/debug.js",
       "static/js/vendor/mutation-summary.js",
       "static/js/vendor/blur.js",
       "static/js/shared/utils.js",

--- a/static/js/background/delegate.js
+++ b/static/js/background/delegate.js
@@ -15,7 +15,7 @@ Delegate.prototype.options.configURL = "https://raw.github.com/waltzio/waltz/mas
 Delegate.prototype.options.backupConfigURL = chrome.extension.getURL("build/site_configs.json");
 
 if (Delegate.prototype.DEBUG) {
-	Delegate.prototype.options.configURL = Delegate.prototype.options.backupConfigURL;
+    Delegate.prototype.options.configURL = Delegate.prototype.options.backupConfigURL;
     debug.enable('waltz:*');
 }
 

--- a/static/js/background/delegate.js
+++ b/static/js/background/delegate.js
@@ -16,6 +16,7 @@ Delegate.prototype.options.backupConfigURL = chrome.extension.getURL("build/site
 
 if (Delegate.prototype.DEBUG) {
 	Delegate.prototype.options.configURL = Delegate.prototype.options.backupConfigURL;
+    debug.enable('debug:*');
 }
 
 function Delegate(opts) {
@@ -207,7 +208,7 @@ Delegate.prototype.getSiteConfigs = function(request, cb) {
      return true;
 };
 
-Delegate.prototype.acknowledgeLoginAttempt = function(request) {
+Delegate.prototype.acknowledgeLoginAttempt = function(request, cb) {
 
     if (request.successful) {
         // If the login is successful, let's refresh other potential tabs
@@ -225,6 +226,8 @@ Delegate.prototype.acknowledgeLoginAttempt = function(request) {
     }
 
     delete(this.currentLogins[request.domain]);
+
+    if (typeof(cb) == "function") cb();
 };
 
 Delegate.prototype.login = function(request, cb) {
@@ -698,6 +701,7 @@ Delegate.prototype.initialize = function(data, callback) {
     }
     _this.refreshOptions({}, function() {
         options.cyHost = _this.options.cy_url;
+        options.debug = Delegate.prototype.DEBUG;
         callback(options);
     });
     return true;

--- a/static/js/background/delegate.js
+++ b/static/js/background/delegate.js
@@ -16,7 +16,7 @@ Delegate.prototype.options.backupConfigURL = chrome.extension.getURL("build/site
 
 if (Delegate.prototype.DEBUG) {
 	Delegate.prototype.options.configURL = Delegate.prototype.options.backupConfigURL;
-    debug.enable('debug:*');
+    debug.enable('waltz:*');
 }
 
 function Delegate(opts) {

--- a/static/js/client/waltz.js
+++ b/static/js/client/waltz.js
@@ -443,29 +443,30 @@
                 $newPassword = $password.clone();
 
                 // Position the cloned login fields precisely over the actual ones
-                var loginPosition = $login.position();
+                var loginPosition = $login.offset();
+                $newLogin.attr('style', getComputedStyle($login[0]).cssText);
                 $newLogin.css({
                     position: 'absolute',
                     top: loginPosition.top,
                     left: loginPosition.left,
-                    width: $login.css('width'),
-                    height: $login.css('height'),
-                    'margin-left': $login.css('margin-left'),
-                    'margin-top': $login.css('margin-top')
+                    'z-index': 1000
                 });
-                var passwordPosition = $password.position();
+                var passwordPosition = $password.offset();
+                $newPassword.attr('style', getComputedStyle($password[0]).cssText);
                 $newPassword.css({
                     position: 'absolute',
                     top: passwordPosition.top,
                     left: passwordPosition.left,
-                    width: $password.css('width'),
-                    height: $password.css('height'),
-                    'margin-left': $password.css('margin-left'),
-                    'margin-top': $password.css('margin-top')
+                    'z-index': 1000
                 });
 
-                $newLogin.insertAfter($login);
-                $newPassword.insertAfter($password);
+                if (_this.blurred) {
+                    $newLogin.Vague({intensity: 4}).blur();
+                    $newPassword.Vague({intensity: 4}).blur();
+                }
+
+                $('body').append($newLogin);
+                $('body').append($newPassword);
 
                 $newLogin.attr('id', _this.CLONED_USERNAME_ID);
                 $newPassword.attr('id', _this.CLONED_PASSWORD_ID);
@@ -801,6 +802,7 @@
                 left = loginForm.container.offset().left;
 
             var blur = loginForm.container.Vague({intensity: 4 });
+            this.blurred = true;
             blur.blur();
 
             $button = $("<div>").attr('id', this.MAIN_BUTTON_ID);
@@ -839,6 +841,7 @@
                 e.stopPropagation();
                 $wrapper.off('mouseenter').off('mouseleave');
                 blur.unblur();
+                _this.blurred = true;
                 clearTimeout(hoverTimeout);
                 _this.dismiss();
             });

--- a/static/js/client/waltz.js
+++ b/static/js/client/waltz.js
@@ -119,6 +119,8 @@
                     log('on unknown page... waiting');
                     _this.acknowledgeLoginAttempt({ success: true, delay: 500 });
                     _this.pageIsBeingHandled.resolve();
+                } else {
+                    _this.pageIsBeingHandled.resolve();
                 }
             }
             // No login is in progress

--- a/static/js/client/waltz.js
+++ b/static/js/client/waltz.js
@@ -841,7 +841,7 @@
                 e.stopPropagation();
                 $wrapper.off('mouseenter').off('mouseleave');
                 blur.unblur();
-                _this.blurred = true;
+                _this.blurred = false;
                 clearTimeout(hoverTimeout);
                 _this.dismiss();
             });
@@ -1037,6 +1037,14 @@
         });
 
         if (!$loginForm) return null;
+        // Don't detect a form if there is a Clef login button on the page
+        if ($('iframe[src^="https://clef.io/iframes/button"').length) return;
+
+        // Don't detect a form that has more than one text/email input
+        if ($loginForm.find("input[type='text']:visible").length +
+            $loginForm.find("input[type='email']:visible").length > 1) return;
+
+
         var $usernameField = $loginForm.find("input[type='text']").first();
         var $passwordField = $loginForm.find("input[type='password']").first();
         var $submitButton = $loginForm.find("input[type='submit'], button").first();

--- a/static/js/client/waltz.js
+++ b/static/js/client/waltz.js
@@ -17,7 +17,7 @@
 
     Waltz.prototype.DISMISSAL_THRESHOLD = 1;
 
-    var log = debug('debug:waltz');
+    var log = debug('waltz:waltz.js');
 
     function Waltz(opts) {
         // If there are no opts, Waltz is not supported on this site
@@ -1059,7 +1059,7 @@
         location: document.location
     }, function(options) {
         if (options.debug) {
-            debug.enable('debug:*');
+            debug.enable('waltz:*');
         }
         new Storage().getDismissalsForSite(options.site.config.key, function(dismissals) {
             var pageSettings = dismissals.pages || {};

--- a/static/js/client/waltz.js
+++ b/static/js/client/waltz.js
@@ -17,6 +17,7 @@
 
     Waltz.prototype.DISMISSAL_THRESHOLD = 1;
 
+    var log = debug('debug:waltz');
 
     function Waltz(opts) {
         // If there are no opts, Waltz is not supported on this site
@@ -36,8 +37,6 @@
 
         this.addDOMObservers();
 
-        var page = this.checkPage();
-        this.handlePage(page);
         this.on('widget.dismissed', this.widgetDismissed.bind(this));
     }
 
@@ -73,16 +72,58 @@
     };
 
     Waltz.prototype.handlePage = function(page) {
-        // First, we need to figure out if the Waltz icon should be displayed.
-        var shouldKickOff = (page == "login" ||
-                (page == "unknown" &&
-                 !this.options.site.config.login.formOnly &&
-                 !this.options.site.config.isAnonymous));
-        if (shouldKickOff && !this.kickedOff) {
-            this.kickOff();
-        } else if (page == "logged_in" && this.options.currentLogin) {
-            this.trigger('loggedIn');
-            this.acknowledgeLoginAttempt({ success: true });
+        var _this = this;
+
+        // If there is as login in progress, mark it as a success or failure.
+        if (_this.options.currentLogin) {
+            log('currentLogin present');
+            // Login has definitely failed.
+            if (page == "login") {
+                log('on login page');
+                if (!_this.iframe) {
+                    _this.loadIFrame();
+                }
+                // Check that the user is still logged in before showing the
+                // credential form
+                _this.checkAuthentication(function() {
+                    var errorMessage = "Invalid username and password.";
+                    _this.acknowledgeLoginAttempt({ success: false });
+                    _this.showWidget();
+                    _this.requestCredentials(errorMessage);
+                }, function() {
+                    // If the user has logged out, then acknowledge the
+                    // existing login attempt to reset login state
+                    _this.acknowledgeLoginAttempt({ success: true });
+                    _this.showWidget();
+                });
+            } 
+            // Login has definitely succeeded.
+            else if (page == "logged_in") {
+                log('on logged in page');
+                this.trigger('loggedIn');
+                this.acknowledgeLoginAttempt({ success: true });
+            } 
+            // Login has probably succeeded.
+            // However, we delay the acknowledgement to ensure any
+            // dynamically loaded login/error forms have a chance to load.
+            else if (page == "unknown" && !this.waiting) {
+                this.waiting = true;
+                log('on unknown page... waiting');
+                this.acknowledgeLoginAttempt({ success: true, delay: 500 });
+            }
+        } 
+        // No login is in progress
+        else {
+            log('no login in progress');
+            // Show the widget if the page has a login form or is configured
+            var shouldKickOff = (page == "login" ||
+                    (page == "unknown" &&
+                    !this.options.site.config.login.formOnly &&
+                    !this.options.site.config.isAnonymous));
+            if (shouldKickOff && !this.kickedOff) {
+                log('kicking off...');
+                this.kickOff();
+            }
         }
     };
 
@@ -94,23 +135,7 @@
         _this.storage.getCredentialsForDomain(_this.options.site.config.key, function (creds) {
 
             _this.loginCredentials = creds;
-
-            if (_this.options.currentLogin) {
-                if (!_this.iframe) {
-                    _this.loadIFrame();
-                }
-                _this.checkAuthentication(function() {
-                    var errorMessage = "Invalid username and password.";
-                    _this.acknowledgeLoginAttempt({ success: false });
-                    _this.showWidget();
-                    _this.requestCredentials(errorMessage);
-                }, function() {
-                    _this.acknowledgeLoginAttempt({ success: true });
-                    _this.showWidget();
-                });
-            } else {
-                _this.showWidget();
-            }
+            _this.showWidget();
 
             window.addEventListener('message', _this.closeIFrame.bind(_this));
             window.addEventListener('message', _this.thirdPartyCookiesCheck.bind(_this));
@@ -206,20 +231,31 @@
     };
 
     Waltz.prototype.acknowledgeLoginAttempt = function(opts) {
-        if (this.options.currentLogin) {
-            if (opts.success) {
-                this.trigger('login.success');
-                if (this.$widget) this.hideWidget();
-            } else {
-                this.trigger('login.failure');
+        var _this = this;
+        var acknowledge = function() {
+            if (_this.waiting) _this.waiting = false;
+            if (_this.options.currentLogin) {
+                if (opts.success) {
+                    log('acknowledge login success');
+                    _this.trigger('login.success');
+                    if (_this.$widget) _this.hideWidget();
+                } else {
+                    log('acknowledge login failure');
+                    _this.trigger('login.failure');
+                }
+                chrome.runtime.sendMessage({
+                    method: "acknowledgeLoginAttempt",
+                    domain: _this.options.site.domain,
+                    key: _this.options.site.config.key,
+                    successful: opts.success
+                });
+                _this.options.currentLogin = null;
             }
-            chrome.runtime.sendMessage({
-                method: "acknowledgeLoginAttempt",
-                domain: this.options.site.domain,
-                key: this.options.site.config.key,
-                successful: opts.success
-            });
-            this.options.currentLogin = null;
+        }
+        if (opts.delay) {
+            setTimeout(acknowledge, opts.delay);
+        } else {
+            acknowledge();
         }
     };
 
@@ -391,30 +427,29 @@
                 $newPassword = $password.clone();
 
                 // Position the cloned login fields precisely over the actual ones
-                var loginPosition = $login.offset();
-                $newLogin.attr('style', getComputedStyle($login[0]).cssText);
+                var loginPosition = $login.position();
                 $newLogin.css({
                     position: 'absolute',
                     top: loginPosition.top,
                     left: loginPosition.left,
-                    'z-index': 1000
+                    width: $login.css('width'),
+                    height: $login.css('height'),
+                    'margin-left': $login.css('margin-left'),
+                    'margin-top': $login.css('margin-top')
                 });
-                var passwordPosition = $password.offset();
-                $newPassword.attr('style', getComputedStyle($password[0]).cssText);
+                var passwordPosition = $password.position();
                 $newPassword.css({
                     position: 'absolute',
                     top: passwordPosition.top,
                     left: passwordPosition.left,
-                    'z-index': 1000
+                    width: $password.css('width'),
+                    height: $password.css('height'),
+                    'margin-left': $password.css('margin-left'),
+                    'margin-top': $password.css('margin-top')
                 });
 
-                if (_this.blurred) {
-                    $newLogin.Vague({intensity: 4}).blur();
-                    $newPassword.Vague({intensity: 4}).blur();
-                }
-
-                $('body').append($newLogin);
-                $('body').append($newPassword);
+                $newLogin.insertAfter($login);
+                $newPassword.insertAfter($password);
 
                 $newLogin.attr('id', _this.CLONED_USERNAME_ID);
                 $newPassword.attr('id', _this.CLONED_PASSWORD_ID);
@@ -504,12 +539,14 @@
                     // a false-positive error dialog for ajax logins)
                     if (_this.DOMObserver) _this.DOMObserver.disconnect();
                     $overlay.click();
-                    if (_this.DOMObserver) _this.DOMObserver.reconnect();
                 }
 
                 // hack to fix issues where submit button
                 // has name="submit" -- WAY TOO HARD
-                if (typeof($form[0].submit) !== "function") {
+                var hasInputNamedSubmit = function(form) { 
+                    return typeof(form.submit != "function"); 
+                };
+                if (_.some($form, hasInputNamedSubmit)) {
                     $form = $form.clone();
                     $form.find('input[name="submit"], #submit').remove();
                     $form.css('display', 'none');
@@ -534,16 +571,14 @@
             method: "hasOngoingAJAXRequest"
         }, function(hasOngoingRequest) {
             if (!hasOngoingRequest) {
+                log('showLoginError');
                 _this.options.site.config.login.loginForm.container.find('input').val('');
                 var $clonedFields = $('#' + _this.CLONED_USERNAME_ID)
                     .add($('#' + _this.CLONED_PASSWORD_ID));
                 $clonedFields.remove();
                 var page = _this.checkPage();
-                if (page == "login") {
-                    var errorMessage = "Invalid username and password.";
-                    _this.acknowledgeLoginAttempt({ success: false });
-                    _this.requestCredentials(errorMessage);
-                }
+                _this.handlePage(page);
+                if (_this.DOMObserver) _this.DOMObserver.reconnect();
             }
         });
 
@@ -749,7 +784,6 @@
                 left = loginForm.container.offset().left;
 
             var blur = loginForm.container.Vague({intensity: 4 });
-            _this.blurred = true;
             blur.blur();
 
             $button = $("<div>").attr('id', this.MAIN_BUTTON_ID);
@@ -788,7 +822,6 @@
                 e.stopPropagation();
                 $wrapper.off('mouseenter').off('mouseleave');
                 blur.unblur();
-                _this.blurred = false;
                 clearTimeout(hoverTimeout);
                 _this.dismiss();
             });
@@ -869,7 +902,7 @@
                 siteConfig.login.loginForm = loginForm;
                 return "login";
             } else {
-                return "logged_in";
+                return "unknown";
             }
         }
 
@@ -984,20 +1017,11 @@
         });
 
         if (!$loginForm) return null;
-
-        // Don't detect a form if there is a Clef login button on the page
-        if ($('iframe[src^="https://clef.io/iframes/button"').length) return;
-
-        // Don't detect a form that has more than one text/email input
-        if ($loginForm.find("input[type='text']:visible").length + 
-            $loginForm.find("input[type='email']:visible").length > 1) return;
-
         var $usernameField = $loginForm.find("input[type='text']").first();
         var $passwordField = $loginForm.find("input[type='password']").first();
         var $submitButton = $loginForm.find("input[type='submit'], button").first();
 
         var $emailField = $loginForm.find("input[type='email']");
-
         if ($emailField.length) $usernameField = $emailField.first();
 
         var commonUsernameClasses = ['login', 'uid', 'email', 'user', 'username'];
@@ -1019,6 +1043,9 @@
         method: "initialize",
         location: document.location
     }, function(options) {
+        if (options.debug) {
+            debug.enable('debug:*');
+        }
         new Storage().getDismissalsForSite(options.site.config.key, function(dismissals) {
             var pageSettings = dismissals.pages || {};
             var pathSettings = pageSettings[window.location.pathname];

--- a/static/js/vendor/debug.js
+++ b/static/js/vendor/debug.js
@@ -1,0 +1,461 @@
+!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.debug=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
+
+/**
+ * This is the web browser implementation of `debug()`.
+ *
+ * Expose `debug()` as the module.
+ */
+
+exports = module.exports = _dereq_('./debug');
+exports.log = log;
+exports.formatArgs = formatArgs;
+exports.save = save;
+exports.load = load;
+exports.useColors = useColors;
+
+/**
+ * Colors.
+ */
+
+exports.colors = [
+  'lightseagreen',
+  'forestgreen',
+  'goldenrod',
+  'dodgerblue',
+  'darkorchid',
+  'crimson'
+];
+
+/**
+ * Currently only WebKit-based Web Inspectors and the Firebug
+ * extension (*not* the built-in Firefox web inpector) are
+ * known to support "%c" CSS customizations.
+ *
+ * TODO: add a `localStorage` variable to explicitly enable/disable colors
+ */
+
+function useColors() {
+  // is webkit? http://stackoverflow.com/a/16459606/376773
+  return ('WebkitAppearance' in document.documentElement.style) ||
+    // is firebug? http://stackoverflow.com/a/398120/376773
+    (window.console && (console.firebug || (console.exception && console.table)));
+}
+
+/**
+ * Map %j to `JSON.stringify()`, since no Web Inspectors do that by default.
+ */
+
+exports.formatters.j = function(v) {
+  return JSON.stringify(v);
+};
+
+
+/**
+ * Colorize log arguments if enabled.
+ *
+ * @api public
+ */
+
+function formatArgs() {
+  var args = arguments;
+  var useColors = this.useColors;
+
+  args[0] = (useColors ? '%c' : '')
+    + this.namespace
+    + (useColors ? '%c ' : ' ')
+    + args[0]
+    + (useColors ? '%c ' : ' ')
+    + '+' + exports.humanize(this.diff);
+
+  if (!useColors) return args
+
+  var c = 'color: ' + this.color;
+  args = [args[0], c, ''].concat(Array.prototype.slice.call(args, 1));
+
+  // the final "%c" is somewhat tricky, because there could be other
+  // arguments passed either before or after the %c, so we need to
+  // figure out the correct index to insert the CSS into
+  var index = 0;
+  var lastC = 0;
+  args[0].replace(/%[a-z%]/g, function(match) {
+    if ('%%' === match) return;
+    index++;
+    if ('%c' === match) {
+      // we only are interested in the *last* %c
+      // (the user may have provided their own)
+      lastC = index;
+    }
+  });
+
+  args.splice(lastC, 0, c);
+  return args;
+}
+
+/**
+ * Invokes `console.log()` when available.
+ * No-op when `console.log` is not a "function".
+ *
+ * @api public
+ */
+
+function log() {
+  // This hackery is required for IE8,
+  // where the `console.log` function doesn't have 'apply'
+  return 'object' == typeof console
+    && 'function' == typeof console.log
+    && Function.prototype.apply.call(console.log, console, arguments);
+}
+
+/**
+ * Save `namespaces`.
+ *
+ * @param {String} namespaces
+ * @api private
+ */
+
+function save(namespaces) {
+  try {
+    if (null == namespaces) {
+      localStorage.removeItem('debug');
+    } else {
+      localStorage.debug = namespaces;
+    }
+  } catch(e) {}
+}
+
+/**
+ * Load `namespaces`.
+ *
+ * @return {String} returns the previously persisted debug modes
+ * @api private
+ */
+
+function load() {
+  var r;
+  try {
+    r = localStorage.debug;
+  } catch(e) {}
+  return r;
+}
+
+/**
+ * Enable namespaces listed in `localStorage.debug` initially.
+ */
+
+exports.enable(load());
+
+},{"./debug":2}],2:[function(_dereq_,module,exports){
+
+/**
+ * This is the common logic for both the Node.js and web browser
+ * implementations of `debug()`.
+ *
+ * Expose `debug()` as the module.
+ */
+
+exports = module.exports = debug;
+exports.coerce = coerce;
+exports.disable = disable;
+exports.enable = enable;
+exports.enabled = enabled;
+exports.humanize = _dereq_('ms');
+
+/**
+ * The currently active debug mode names, and names to skip.
+ */
+
+exports.names = [];
+exports.skips = [];
+
+/**
+ * Map of special "%n" handling functions, for the debug "format" argument.
+ *
+ * Valid key names are a single, lowercased letter, i.e. "n".
+ */
+
+exports.formatters = {};
+
+/**
+ * Previously assigned color.
+ */
+
+var prevColor = 0;
+
+/**
+ * Previous log timestamp.
+ */
+
+var prevTime;
+
+/**
+ * Select a color.
+ *
+ * @return {Number}
+ * @api private
+ */
+
+function selectColor() {
+  return exports.colors[prevColor++ % exports.colors.length];
+}
+
+/**
+ * Create a debugger with the given `namespace`.
+ *
+ * @param {String} namespace
+ * @return {Function}
+ * @api public
+ */
+
+function debug(namespace) {
+
+  // define the `disabled` version
+  function disabled() {
+  }
+  disabled.enabled = false;
+
+  // define the `enabled` version
+  function enabled() {
+
+    var self = enabled;
+
+    // set `diff` timestamp
+    var curr = +new Date();
+    var ms = curr - (prevTime || curr);
+    self.diff = ms;
+    self.prev = prevTime;
+    self.curr = curr;
+    prevTime = curr;
+
+    // add the `color` if not set
+    if (null == self.useColors) self.useColors = exports.useColors();
+    if (null == self.color && self.useColors) self.color = selectColor();
+
+    var args = Array.prototype.slice.call(arguments);
+
+    args[0] = exports.coerce(args[0]);
+
+    if ('string' !== typeof args[0]) {
+      // anything else let's inspect with %o
+      args = ['%o'].concat(args);
+    }
+
+    // apply any `formatters` transformations
+    var index = 0;
+    args[0] = args[0].replace(/%([a-z%])/g, function(match, format) {
+      // if we encounter an escaped % then don't increase the array index
+      if (match === '%%') return match;
+      index++;
+      var formatter = exports.formatters[format];
+      if ('function' === typeof formatter) {
+        var val = args[index];
+        match = formatter.call(self, val);
+
+        // now we need to remove `args[index]` since it's inlined in the `format`
+        args.splice(index, 1);
+        index--;
+      }
+      return match;
+    });
+
+    if ('function' === typeof exports.formatArgs) {
+      args = exports.formatArgs.apply(self, args);
+    }
+    var logFn = exports.log || enabled.log || console.log.bind(console);
+    logFn.apply(self, args);
+  }
+  enabled.enabled = true;
+
+  var fn = exports.enabled(namespace) ? enabled : disabled;
+
+  fn.namespace = namespace;
+
+  return fn;
+}
+
+/**
+ * Enables a debug mode by namespaces. This can include modes
+ * separated by a colon and wildcards.
+ *
+ * @param {String} namespaces
+ * @api public
+ */
+
+function enable(namespaces) {
+  exports.save(namespaces);
+
+  var split = (namespaces || '').split(/[\s,]+/);
+  var len = split.length;
+
+  for (var i = 0; i < len; i++) {
+    if (!split[i]) continue; // ignore empty strings
+    namespaces = split[i].replace('*', '.*?');
+    if (namespaces[0] === '-') {
+      exports.skips.push(new RegExp('^' + namespaces.substr(1) + '$'));
+    } else {
+      exports.names.push(new RegExp('^' + namespaces + '$'));
+    }
+  }
+}
+
+/**
+ * Disable debug output.
+ *
+ * @api public
+ */
+
+function disable() {
+  exports.enable('');
+}
+
+/**
+ * Returns true if the given mode name is enabled, false otherwise.
+ *
+ * @param {String} name
+ * @return {Boolean}
+ * @api public
+ */
+
+function enabled(name) {
+  var i, len;
+  for (i = 0, len = exports.skips.length; i < len; i++) {
+    if (exports.skips[i].test(name)) {
+      return false;
+    }
+  }
+  for (i = 0, len = exports.names.length; i < len; i++) {
+    if (exports.names[i].test(name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Coerce `val`.
+ *
+ * @param {Mixed} val
+ * @return {Mixed}
+ * @api private
+ */
+
+function coerce(val) {
+  if (val instanceof Error) return val.stack || val.message;
+  return val;
+}
+
+},{"ms":3}],3:[function(_dereq_,module,exports){
+/**
+ * Helpers.
+ */
+
+var s = 1000;
+var m = s * 60;
+var h = m * 60;
+var d = h * 24;
+var y = d * 365.25;
+
+/**
+ * Parse or format the given `val`.
+ *
+ * Options:
+ *
+ *  - `long` verbose formatting [false]
+ *
+ * @param {String|Number} val
+ * @param {Object} options
+ * @return {String|Number}
+ * @api public
+ */
+
+module.exports = function(val, options){
+  options = options || {};
+  if ('string' == typeof val) return parse(val);
+  return options.long
+    ? long(val)
+    : short(val);
+};
+
+/**
+ * Parse the given `str` and return milliseconds.
+ *
+ * @param {String} str
+ * @return {Number}
+ * @api private
+ */
+
+function parse(str) {
+  var match = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i.exec(str);
+  if (!match) return;
+  var n = parseFloat(match[1]);
+  var type = (match[2] || 'ms').toLowerCase();
+  switch (type) {
+    case 'years':
+    case 'year':
+    case 'y':
+      return n * y;
+    case 'days':
+    case 'day':
+    case 'd':
+      return n * d;
+    case 'hours':
+    case 'hour':
+    case 'h':
+      return n * h;
+    case 'minutes':
+    case 'minute':
+    case 'm':
+      return n * m;
+    case 'seconds':
+    case 'second':
+    case 's':
+      return n * s;
+    case 'ms':
+      return n;
+  }
+}
+
+/**
+ * Short format for `ms`.
+ *
+ * @param {Number} ms
+ * @return {String}
+ * @api private
+ */
+
+function short(ms) {
+  if (ms >= d) return Math.round(ms / d) + 'd';
+  if (ms >= h) return Math.round(ms / h) + 'h';
+  if (ms >= m) return Math.round(ms / m) + 'm';
+  if (ms >= s) return Math.round(ms / s) + 's';
+  return ms + 'ms';
+}
+
+/**
+ * Long format for `ms`.
+ *
+ * @param {Number} ms
+ * @return {String}
+ * @api private
+ */
+
+function long(ms) {
+  return plural(ms, d, 'day')
+    || plural(ms, h, 'hour')
+    || plural(ms, m, 'minute')
+    || plural(ms, s, 'second')
+    || ms + ' ms';
+}
+
+/**
+ * Pluralization helper.
+ */
+
+function plural(ms, n, name) {
+  if (ms < n) return;
+  if (ms < n * 1.5) return Math.floor(ms / n) + ' ' + name;
+  return Math.ceil(ms / n) + ' ' + name + 's';
+}
+
+},{}]},{},[1])
+(1)
+});

--- a/static/scss/_credentials.scss
+++ b/static/scss/_credentials.scss
@@ -59,7 +59,7 @@ $main-padding: 20px;
     -webkit-transition: .2s;
     position: relative;
     color: black;
-    
+
     font-family: $font-family;
 
     h1, h2, h3, h4, h5, h6, p {
@@ -92,9 +92,9 @@ $main-padding: 20px;
         background: transparent;
     }
 
-    #waltz-credential-username, 
+    #waltz-credential-username,
     #waltz-credential-password,
-    #waltz-credential-submit, 
+    #waltz-credential-submit,
     #waltz-credential-alert,
     #waltz-first-share {
         font-family: $font-family;
@@ -149,7 +149,7 @@ $main-padding: 20px;
             font-size: 12px;
             line-height: 16px;
             color: #888;
-            margin: 25px 0 10px 0; 
+            margin: 25px 0 10px 0;
             font-weight: 300;
             font-family: $font-family;
             padding: 0;
@@ -160,7 +160,7 @@ $main-padding: 20px;
     #waltz-credential-alert {
         font-size: 14px;
         background-color: #f65058;
-        color: white;   
+        color: white;
         padding: 10px;
     }
 


### PR DESCRIPTION
- state is now separated into two categories: login in progress, or no login in progress
- if a login form is detected, then login has failed
- if no login form is detected and there is no check selector, we wait 500ms and then mark the login as successful

This prevents errors where the Waltz credential form was popping up at inappropriate times,
since the page was being checked before a check selector was loaded.

Also:
- some UI fixes for the cloned login form
- added the debug logging module 
