### PR TITLE
Fix issue where logout fails on wakeup with no internet connectivity

### DIFF
--- a/static/js/background/delegate.js
+++ b/static/js/background/delegate.js
@@ -151,15 +151,6 @@ Delegate.prototype.init = function(options) {
 
     // bind the router
     chrome.runtime.onMessage.addListener(this.router.bind(this));
-    window.addEventListener('online', function() {
-        setTimeout(function() {
-            _this.checkAuthentication(function(data) {
-                if (!data.user) {
-                    _this.logout({ silent: true });
-                }
-            });
-        }, 2000);
-    });
 
     // when the configs are done loading, blast off, baby!
     $.when(this.configsLoaded).then(kickOff);


### PR DESCRIPTION
Waltz has had an issue for some time where logout was failing on wakeup because the siteConfigs were not loaded when logout was called.

I _believe_ that this issue is caused by the chunk of code that is removed by this PR. From what I can tell, it serves the exact same purpose as the code [here](https://github.com/waltzio/waltz/blob/develop/static/js/background/delegate.js#L147), except it doesn't wait for configs to be loaded — only for the navigator to be online.

@landakram can you review when you get a chance
