### PR TITLE
Add url to duolingo site config

### DIFF
--- a/site_configs/duolingo.json
+++ b/site_configs/duolingo.json
@@ -5,7 +5,7 @@
             "cookies": ["duo_main_session", "auth_tkt", "wuuid"]
         },
         "login": {
-            "urls": [],
+            "urls": ["https://www.duolingo.com/"],
             "formURL": "http://www.duolingo.com/login",
             "method": "POST",
             "usernameField": "login",


### PR DESCRIPTION
Hyperlink currently redirects to `undefined` because of site.login.urls[0] is used as the href for each link (line 40 `/static/js/client/sites.js`)

Disclaimer: I have not tested these changes!
